### PR TITLE
feat: exposes the prom-client register to allow adding custom metrics

### DIFF
--- a/src/factories/createIapetus.js
+++ b/src/factories/createIapetus.js
@@ -37,6 +37,7 @@ export default (userIapetusConfiguration?: IapetusConfigurationType): IapetusTyp
     log.warn('Iapetus could not detect Kubernetes; operating in a no-op mode');
 
     return {
+      register: null,
       createCounterMetric: () => {
         return {
           increment: () => {}
@@ -84,6 +85,7 @@ export default (userIapetusConfiguration?: IapetusConfigurationType): IapetusTyp
   });
 
   return {
+    register,
     createCounterMetric: (configuration) => {
       const counter = new Counter({
         help: configuration.description || 'N/A',


### PR DESCRIPTION
This PR simply exposes the currently privately held `prom-client` register. It should not be seen as a PR that solves the issues #1 and #2 but more as an addition so users can choose between using the custom API and the API of `prom-client`. 